### PR TITLE
Fix #18 & Fix #20

### DIFF
--- a/Upload/inc/plugins/ougc_customrep.php
+++ b/Upload/inc/plugins/ougc_customrep.php
@@ -500,7 +500,7 @@ function ougc_customrep_postbit(&$post)
 
 	if(!isset($customrep->cache['query']))
 	{
-		global $settings;
+		global $mybb;
 
 		$customrep->set_forum($fid);
 


### PR DESCRIPTION
Fix #18 get_class() called without object from outside a class
Fix #20 Call to a member function get_input() on a non-object
